### PR TITLE
fix: fix erroneous behaviour when running the script as `root`

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -26,6 +26,7 @@ import os
 import pathlib
 import platform
 import subprocess
+import sys
 import tarfile
 import urllib.error
 import urllib.request
@@ -327,4 +328,9 @@ def get_token(pat: str) -> str:
 
 
 if __name__ == "__main__":
-    main()
+    # Check if script invoked by the "root" user, if so throw error message and exit
+    if not os.geteuid() == 0:
+        main()
+    else:
+        logging.error("Must run script as non-root user!")
+        sys.exit(1)


### PR DESCRIPTION
This PR refactors the `install.py` script to check whether it is invoked by the `root` user, if so, throw an error and exit. This is done to avoid erroneous behaviour wherein the script executes halfway through only to break down midway.

See #2 for more information on the same.